### PR TITLE
Lock Free State, Solves Deadlocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
+name = "async-channel"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59386c3aa61f4e14c4ddda1a6744c119b4bf278ec9f866d3c20bc5728ee0eb97"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+
+[[package]]
 name = "cc"
 version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -390,6 +416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
+name = "event-listener"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cd41440ae7e4734bbd42302f63eaba892afc93a3912dad84006247f0dedb0e"
+
+[[package]]
 name = "fastrand"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +563,7 @@ dependencies = [
 name = "game-server"
 version = "0.1.0"
 dependencies = [
+ "async-channel",
  "async-trait",
  "bytes",
  "chrono",
@@ -1542,6 +1575,7 @@ version = "0.1.0"
 name = "tq-network"
 version = "0.1.0"
 dependencies = [
+ "async-channel",
  "async-trait",
  "bytes",
  "derive-packethandler",

--- a/core/network/Cargo.toml
+++ b/core/network/Cargo.toml
@@ -14,6 +14,8 @@ tq-crypto = { path = "../crypto" }
 async-trait = "0.1"
 tracing = "0.1"
 tracing-futures = "0.2"
+async-channel = "1.4"
+
 # macros
 derive-packetid = { path = "../../macros/derive-packetid" }
 derive-packethandler = { path = "../../macros/derive-packethandler" }
@@ -21,5 +23,5 @@ derive-packethandler = { path = "../../macros/derive-packethandler" }
 [dependencies.tokio]
 version = "0.2"
 default-features = false
-features = ["rt-core", "io-util", "net", "stream", "sync", "macros"]
+features = ["rt-core", "io-util", "net", "macros", "stream"]
 

--- a/core/network/src/errors.rs
+++ b/core/network/src/errors.rs
@@ -1,6 +1,6 @@
+use async_channel::SendError;
 use std::{backtrace::Backtrace, option::NoneError};
 use thiserror::Error;
-use tokio::sync::mpsc::error::SendError;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/core/network/src/lib.rs
+++ b/core/network/src/lib.rs
@@ -13,7 +13,7 @@ mod errors;
 pub use errors::Error;
 
 mod actor;
-pub use actor::{Actor, Message};
+pub use actor::{Actor, ActorState, Message};
 
 mod server;
 pub use server::Server;
@@ -25,7 +25,7 @@ pub trait PacketID {
 #[async_trait]
 pub trait PacketProcess {
     type Error: StdError;
-    type ActorState: Default + Send + Sync;
+    type ActorState: ActorState;
     /// Process can be invoked by a packet after decode has been called to
     /// structure packet fields and properties. For the server
     /// implementations, this is called in the packet handler after the
@@ -61,7 +61,7 @@ pub trait PacketDecode {
 #[async_trait]
 pub trait PacketHandler {
     type Error: StdError + PacketEncode + Send + Sync;
-    type ActorState: Default + Send + Sync;
+    type ActorState: ActorState;
     async fn handle(
         packet: (u16, Bytes),
         actor: &Actor<Self::ActorState>,

--- a/server/game/Cargo.toml
+++ b/server/game/Cargo.toml
@@ -23,6 +23,7 @@ once_cell = "1.4"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 fastrand = "1.3"
 encoding = "0.2"
+async-channel = "1.4"
 
 # Utils
 [dependencies.num_enum]
@@ -33,7 +34,7 @@ default-features = false
 [dependencies.tokio]
 version = "0.2"
 default-features = false
-features = ["rt-threaded", "macros", "signal"]
+features = ["rt-threaded", "macros", "signal", "stream", "sync"]
 
 # Database
 [dependencies.sqlx]

--- a/server/game/src/errors.rs
+++ b/server/game/src/errors.rs
@@ -1,3 +1,4 @@
+use async_channel::SendError;
 use bytes::Bytes;
 use thiserror::Error;
 use tq_network::{ErrorPacket, PacketEncode};
@@ -16,6 +17,8 @@ pub enum Error {
     Db(#[from] sqlx::Error),
     #[error("State Error: {}", _0)]
     State(&'static str),
+    #[error("Actor State Send Error!")]
+    SendError,
     #[error(transparent)]
     ParseInt(#[from] std::num::ParseIntError),
     #[error(transparent)]
@@ -24,6 +27,10 @@ pub enum Error {
     Other(String),
     #[error("Msg {}", _0)]
     Msg(u16, Bytes),
+}
+
+impl<T> From<SendError<T>> for Error {
+    fn from(_: SendError<T>) -> Self { Self::SendError }
 }
 
 impl<T: PacketEncode> From<ErrorPacket<T>> for Error {

--- a/server/game/src/main.rs
+++ b/server/game/src/main.rs
@@ -35,11 +35,8 @@ impl Server for GameServer {
     async fn on_disconnected(
         actor: Actor<Self::ActorState>,
     ) -> Result<(), tq_network::Error> {
-        actor
-            .state()
-            .on_disconnect(actor.id())
-            .await
-            .unwrap_or_default();
+        let mystate = actor.state();
+        tq_network::ActorState::dispose(mystate, &actor).unwrap_or_default();
         Ok(())
     }
 }

--- a/server/game/src/packets/msg_action.rs
+++ b/server/game/src/packets/msg_action.rs
@@ -48,19 +48,19 @@ impl PacketProcess for MsgAction {
         actor: &Actor<Self::ActorState>,
     ) -> Result<(), Self::Error> {
         let ty = self.action_type.into();
-        let state = actor.state();
+        let mystate = actor.state();
         match ty {
             ActionType::SetLocation => {
                 let mut res = self.clone();
-                let character = state.character().await;
-                res.param0 = character.inner().map_id as u32;
+                let character = mystate.character().await?;
+                res.param0 = character.map_id as u32;
                 res.param1 = character.x();
                 res.param2 = character.y();
                 actor.send(res).await?;
             },
             ActionType::SetMapARGB => {
                 let mut res = self.clone();
-                let character = state.character().await;
+                let character = mystate.character().await?;
                 res.param0 = 0x00FF_FFFF;
                 res.param1 = character.x();
                 res.param2 = character.y();

--- a/server/game/src/packets/msg_connect.rs
+++ b/server/game/src/packets/msg_connect.rs
@@ -38,9 +38,13 @@ impl PacketProcess for MsgConnect {
         let maybe_character = db::Character::from_account(id).await?;
         match maybe_character {
             Some(character) => {
-                let mut old = actor.state().character_mut().await;
-                *old = Character::new(actor.clone(), character.clone());
-                drop(old);
+                actor
+                    .state()
+                    .set_character(Character::new(
+                        actor.clone(),
+                        character.clone(),
+                    ))
+                    .await?;
                 state
                     .maps()
                     .get(&(character.map_id as u32))

--- a/server/game/src/packets/msg_register.rs
+++ b/server/game/src/packets/msg_register.rs
@@ -124,9 +124,11 @@ impl PacketProcess for MsgRegister {
 
         let character_id = self.build_character(id, realm_id)?.save().await?;
         let character = db::Character::by_id(character_id).await?;
-        let mut old = actor.state().character_mut().await;
         let map_id = character.map_id;
-        *old = Character::new(actor.clone(), character);
+        actor
+            .state()
+            .set_character(Character::new(actor.clone(), character))
+            .await?;
         // Set player map.
         state
             .maps()


### PR DESCRIPTION
Actually not a fully lock-free state, but now it is almost impossible to make a dead-lock by mistake by holding a `WriteLock` and `ReadLock` at the same time, this is achieved by that we separate the state into a separate struct `InnerActorState` that will only make `WriteLock`s while the other state `ActorState` will only hold `ReadLock`s and they communicate over a channel for sending updates.
